### PR TITLE
Don't build forks.

### DIFF
--- a/server.go
+++ b/server.go
@@ -59,6 +59,12 @@ func (s *Server) Push(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Don't build forks.
+	if event.Repository.Fork {
+		io.WriteString(w, "Not building fork")
+		return
+	}
+
 	opts := BuildOptions{
 		Repository: event.Repository.FullName,
 		Branch:     strings.Replace(event.Ref, "refs/heads/", "", -1),

--- a/server_test.go
+++ b/server_test.go
@@ -66,6 +66,39 @@ func TestServer_Push(t *testing.T) {
 	}
 }
 
+func TestServer_Push_Fork(t *testing.T) {
+	var called bool
+	b := func(ctx context.Context, w Logger, opts BuildOptions) (string, error) {
+		called = true
+		return "", nil
+	}
+	s := NewServer(New(BuilderFunc(b)))
+	s.Builder = BuilderFunc(b) // Remove Async
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/", strings.NewReader(`{
+  "ref": "refs/heads/master",
+  "head_commit": {
+    "id": "abcd"
+  },
+  "repository": {
+    "full_name": "remind101/acme-inc",
+    "fork": true
+  }
+}`))
+	req.Header.Set("X-GitHub-Event", "push")
+
+	s.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatal("Expected 200 OK")
+	}
+
+	if called {
+		t.Fatal("Expected builder to have not been called")
+	}
+}
+
 func TestNoCache(t *testing.T) {
 	tests := []struct {
 		in  string


### PR DESCRIPTION
Closes https://github.com/remind101/conveyor/issues/1

Forks will not be built after this change. Eventually, this would be nice to be able to configure, but this is the safest thing for now.
