### PR TITLE
Include a more descriptive reason for why the build was canceled.

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -29,12 +29,13 @@ var (
 // BuildCanceledError is returned if the build is canceled, or times out and the
 // container returns an error.
 type BuildCanceledError struct {
-	Err error
+	Err    error
+	Reason error
 }
 
 // Error implements the error interface.
 func (e *BuildCanceledError) Error() string {
-	return fmt.Sprintf("%s (canceled)", e.Err.Error())
+	return fmt.Sprintf("%s (%s)", e.Err.Error(), e.Reason.Error())
 }
 
 // BuildOptions is provided when building an image.

--- a/builder/docker/docker.go
+++ b/builder/docker/docker.go
@@ -151,7 +151,8 @@ func (b *Builder) Build(ctx context.Context, w io.Writer, opts builder.BuildOpti
 		err := fmt.Errorf("container returned a non-zero exit code: %d", exit)
 		if canceled {
 			err = &builder.BuildCanceledError{
-				Err: err,
+				Err:    err,
+				Reason: ctx.Err(),
 			}
 		}
 		return "", err


### PR DESCRIPTION
Instead of an error message like:

```
container returned a non-zero exit code: 137 (canceled)
```

We'll see:

```
container returned a non-zero exit code: 137 (context canceled)
```

or

```
container returned a non-zero exit code: 137 (context deadline exceeded)
```
