### PR TITLE
BuildQueue

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -1,0 +1,80 @@
+package conveyor
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"github.com/remind101/conveyor/builder"
+	"github.com/remind101/pkg/reporter"
+	"golang.org/x/net/context"
+)
+
+// Builder is an implementation of the builder.Builder interface that adds
+// timeouts and error reporting.
+type Builder struct {
+	builder *builder.CancelBuilder
+
+	// A Reporter to use to report errors.
+	Reporter reporter.Reporter
+
+	// Timeout controls how long to wait before canceling a build. A timeout
+	// of 0 means no timeout.
+	Timeout time.Duration
+}
+
+// NewBuilder returns a new Builder instance backed by b. It also wraps it with
+// cancellation and closes the logs when the build finishes.
+func NewBuilder(b builder.Builder) *Builder {
+	return &Builder{
+		builder: builder.WithCancel(builder.CloseWriter(b)),
+		Timeout: DefaultTimeout,
+	}
+}
+
+// Build builds the image.
+func (b *Builder) Build(ctx context.Context, w io.Writer, opts builder.BuildOptions) (image string, err error) {
+	log.Printf("Starting build: repository=%s branch=%s sha=%s",
+		opts.Repository,
+		opts.Branch,
+		opts.Sha,
+	)
+
+	// Embed the reporter in the context.Context.
+	ctx = reporter.WithReporter(ctx, b.reporter())
+
+	if b.Timeout != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		defer cancel() // Release resources.
+	}
+
+	reporter.AddContext(ctx, "options", opts)
+	defer reporter.Monitor(ctx)
+
+	defer func() {
+		if err != nil {
+			reporter.Report(ctx, err)
+		}
+	}()
+
+	image, err = b.builder.Build(ctx, w, opts)
+	return
+}
+
+func (b *Builder) Cancel() error {
+	return b.builder.Cancel()
+}
+
+func (b *Builder) reporter() reporter.Reporter {
+	if b.Reporter == nil {
+		return reporter.ReporterFunc(func(ctx context.Context, err error) error {
+			fmt.Fprintf(os.Stderr, "reporting err: %v\n", err)
+			return nil
+		})
+	}
+
+	return b.Reporter
+}

--- a/builder.go
+++ b/builder.go
@@ -15,7 +15,7 @@ import (
 // Builder is an implementation of the builder.Builder interface that adds
 // timeouts and error reporting.
 type Builder struct {
-	builder *builder.CancelBuilder
+	builder builder.Builder
 
 	// A Reporter to use to report errors.
 	Reporter reporter.Reporter
@@ -29,7 +29,7 @@ type Builder struct {
 // cancellation and closes the logs when the build finishes.
 func NewBuilder(b builder.Builder) *Builder {
 	return &Builder{
-		builder: builder.WithCancel(builder.CloseWriter(b)),
+		builder: builder.CloseWriter(b),
 		Timeout: DefaultTimeout,
 	}
 }
@@ -62,10 +62,6 @@ func (b *Builder) Build(ctx context.Context, w io.Writer, opts builder.BuildOpti
 
 	image, err = b.builder.Build(ctx, w, opts)
 	return
-}
-
-func (b *Builder) Cancel() error {
-	return b.builder.Cancel()
 }
 
 func (b *Builder) reporter() reporter.Reporter {

--- a/builder_test.go
+++ b/builder_test.go
@@ -1,0 +1,25 @@
+package conveyor
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/remind101/conveyor/builder"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+)
+
+func TestBuilder_Build(t *testing.T) {
+	b := new(mockBuilder)
+	bb := &Builder{
+		builder: b,
+	}
+
+	w := new(bytes.Buffer)
+	options := builder.BuildOptions{}
+
+	b.On("Build", w, options).Return("", nil)
+
+	_, err := bb.Build(context.Background(), w, options)
+	assert.NoError(t, err)
+}

--- a/cmd/conveyor/main.go
+++ b/cmd/conveyor/main.go
@@ -33,16 +33,22 @@ func newConveyor(c *cli.Context) (*conveyor.Conveyor, error) {
 	if err != nil {
 		return nil, err
 	}
-	cv, err := conveyor.New(b), nil
-	if err != nil {
-		return cv, err
-	}
+
 	r, err := newReporter(c.String("reporter"))
 	if err != nil {
-		return cv, err
+		return nil, err
 	}
-	cv.Reporter = r
-	return cv, nil
+
+	f, err := logFactory(c.String("logger"))
+	if err != nil {
+		return nil, err
+	}
+
+	return conveyor.New(conveyor.Options{
+		Builder:    b,
+		Reporter:   r,
+		LogFactory: f,
+	}), nil
 }
 
 func newBuilder(c *cli.Context) (builder.Builder, error) {
@@ -59,13 +65,6 @@ func newBuilder(c *cli.Context) (builder.Builder, error) {
 
 func newServer(c *cli.Context, b *conveyor.Conveyor) (http.Handler, error) {
 	s := conveyor.NewServer(b)
-
-	f, err := logFactory(c.String("logger"))
-	if err != nil {
-		return nil, err
-	}
-	s.LogFactory = f
-
 	return hookshot.Authorize(s, c.String("github.secret")), nil
 }
 

--- a/cmd/conveyor/main.go
+++ b/cmd/conveyor/main.go
@@ -28,6 +28,8 @@ func main() {
 	}
 }
 
+// newConveyor builds a new Conveyor instance backed by in memory queue and
+// workers.
 func newConveyor(c *cli.Context) (*conveyor.Conveyor, error) {
 	b, err := newBuilder(c)
 	if err != nil {

--- a/cmd/conveyor/main.go
+++ b/cmd/conveyor/main.go
@@ -84,7 +84,6 @@ func logFactory(uri string) (f builder.LogFactory, err error) {
 		f, err = builder.S3Logger(u.Host)
 	}
 
-	// f = conveyor.MultiLogger(conveyor.StdoutLogger, f)
 	return
 }
 

--- a/cmd/conveyor/server.go
+++ b/cmd/conveyor/server.go
@@ -74,7 +74,7 @@ func runServer(c *cli.Context) {
 		sig := <-quit
 
 		log.Printf("Signal %d received. Shutting down.\n", sig)
-		if err := b.Cancel(); err != nil {
+		if err := b.Shutdown(); err != nil {
 			log.Fatal(err)
 		}
 		os.Exit(0)

--- a/cmd/conveyor/server.go
+++ b/cmd/conveyor/server.go
@@ -46,6 +46,12 @@ var cmdServer = cli.Command{
 			EnvVar: "BUILDER_IMAGE",
 		},
 		cli.StringFlag{
+			Name:   "queue",
+			Value:  "memory://",
+			Usage:  "Specify a queue to use for scale out. The default behavior is to spin up workers that consume off of an in memory queue.",
+			EnvVar: "QUEUE",
+		},
+		cli.StringFlag{
 			Name:   "logger",
 			Value:  "stdout://",
 			Usage:  "The logger to use. Available options are `stdout://`, or `s3://bucket`.",

--- a/cmd/conveyor/server.go
+++ b/cmd/conveyor/server.go
@@ -84,6 +84,8 @@ func runServer(c *cli.Context) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	log.Println("Listening on " + port)
+	b.Start()
 	log.Fatal(http.ListenAndServe(":"+port, s))
 }

--- a/cmd/conveyor/server.go
+++ b/cmd/conveyor/server.go
@@ -46,12 +46,6 @@ var cmdServer = cli.Command{
 			EnvVar: "BUILDER_IMAGE",
 		},
 		cli.StringFlag{
-			Name:   "queue",
-			Value:  "memory://",
-			Usage:  "Specify a queue to use for scale out. The default behavior is to spin up workers that consume off of an in memory queue.",
-			EnvVar: "QUEUE",
-		},
-		cli.StringFlag{
 			Name:   "logger",
 			Value:  "stdout://",
 			Usage:  "The logger to use. Available options are `stdout://`, or `s3://bucket`.",

--- a/conveyor.go
+++ b/conveyor.go
@@ -61,6 +61,7 @@ func New(options Options) *Conveyor {
 				Reporter: options.Reporter,
 				Timeout:  DefaultTimeout,
 			},
+			LogFactory: options.LogFactory,
 			BuildQueue: q,
 		})
 	}

--- a/conveyor.go
+++ b/conveyor.go
@@ -36,7 +36,7 @@ type Options struct {
 // Conveyor is a struct that represents something that can build docker images.
 type Conveyor struct {
 	BuildQueue
-	workers []*Worker
+	Workers
 	builder builder.Builder
 }
 
@@ -51,7 +51,7 @@ func New(options Options) *Conveyor {
 		numWorkers = DefaultWorkers
 	}
 
-	var workers []*Worker
+	var workers Workers
 	for i := 0; i < numWorkers; i++ {
 		w := NewWorker(q, b)
 		w.LogFactory = options.LogFactory
@@ -60,35 +60,11 @@ func New(options Options) *Conveyor {
 
 	c := &Conveyor{
 		BuildQueue: q,
-		workers:    workers,
+		Workers:    workers,
 		builder:    b,
 	}
 
 	c.Start()
 
 	return c
-}
-
-// Start each worker in it's own goroutine.
-func (c *Conveyor) Start() {
-	for _, w := range c.workers {
-		go w.Start()
-	}
-}
-
-func (c *Conveyor) Shutdown() error {
-	var errors []error
-
-	// TODO: Use a wait group
-	for _, w := range c.workers {
-		if err := w.Shutdown(); err != nil {
-			errors = append(errors, err)
-		}
-	}
-
-	if len(errors) == 0 {
-		return nil
-	}
-
-	return errors[0]
 }

--- a/conveyor.go
+++ b/conveyor.go
@@ -51,11 +51,9 @@ func New(options Options) *Conveyor {
 
 	var workers []*Worker
 	for i := 0; i < numWorkers; i++ {
-		workers = append(workers, &Worker{
-			Builder:    b,
-			LogFactory: options.LogFactory,
-			BuildQueue: q,
-		})
+		w := NewWorker(q, b)
+		w.LogFactory = options.LogFactory
+		workers = append(workers, w)
 	}
 
 	c := &Conveyor{

--- a/conveyor.go
+++ b/conveyor.go
@@ -1,6 +1,7 @@
 package conveyor
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/remind101/conveyor/builder"
@@ -10,9 +11,11 @@ const (
 	// DefaultTimeout is the default amount of time to wait for a build
 	// to complete before cancelling it.
 	DefaultTimeout = 20 * time.Minute
+)
 
+var (
 	// DefaultWorkers is the default number of workers to start.
-	DefaultWorkers = 100
+	DefaultWorkers = runtime.NumCPU()
 )
 
 // Options provided when initializing a new Conveyor instance.

--- a/conveyor.go
+++ b/conveyor.go
@@ -77,7 +77,9 @@ func (c *Conveyor) Start() {
 }
 
 func (c *Conveyor) Cancel() error {
-	if b, ok := c.builder.(*Builder); ok {
+	if b, ok := c.builder.(interface {
+		Cancel() error
+	}); ok {
 		return b.Cancel()
 	}
 

--- a/conveyor.go
+++ b/conveyor.go
@@ -28,20 +28,24 @@ type Options struct {
 	// The backend used to perform the builds.
 	Builder builder.Builder
 
+	// Number of jobs to buffer in the in memory queue.
+	Buffer int
+
 	// Number of workers to spin up.
 	Workers int
 }
 
-// Conveyor serves as a builder.
+// Conveyor is a struct that represents something that can build docker images.
 type Conveyor struct {
 	BuildQueue
 	workers []*Worker
 	builder builder.Builder
 }
 
-// New returns a new Conveyor instance.
+// New returns a new Conveyor instance that spins up multiple workers consuming
+// from an in memory queue.
 func New(options Options) *Conveyor {
-	q := newBuildQueue(100)
+	q := newBuildQueue(options.Buffer)
 	b := builder.WithCancel(builder.CloseWriter(options.Builder))
 
 	numWorkers := options.Workers

--- a/conveyor.go
+++ b/conveyor.go
@@ -51,12 +51,11 @@ func New(options Options) *Conveyor {
 		numWorkers = DefaultWorkers
 	}
 
-	var workers Workers
-	for i := 0; i < numWorkers; i++ {
-		w := NewWorker(q, b)
-		w.LogFactory = options.LogFactory
-		workers = append(workers, w)
-	}
+	workers := NewWorkerPool(numWorkers, WorkerOptions{
+		Builder:    b,
+		BuildQueue: q,
+		LogFactory: options.LogFactory,
+	})
 
 	c := &Conveyor{
 		BuildQueue: q,
@@ -64,7 +63,8 @@ func New(options Options) *Conveyor {
 		builder:    b,
 	}
 
-	c.Start()
+	// Start the workers.
+	c.Workers.Start()
 
 	return c
 }

--- a/conveyor.go
+++ b/conveyor.go
@@ -1,7 +1,6 @@
 package conveyor
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/remind101/conveyor/builder"
@@ -74,12 +73,19 @@ func (c *Conveyor) Start() {
 	}
 }
 
-func (c *Conveyor) Cancel() error {
-	if b, ok := c.builder.(interface {
-		Cancel() error
-	}); ok {
-		return b.Cancel()
+func (c *Conveyor) Shutdown() error {
+	var errors []error
+
+	// TODO: Use a wait group
+	for _, w := range c.workers {
+		if err := w.Shutdown(); err != nil {
+			errors = append(errors, err)
+		}
 	}
 
-	return fmt.Errorf("Builder does not support Cancel()")
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return errors[0]
 }

--- a/conveyor.go
+++ b/conveyor.go
@@ -2,121 +2,87 @@ package conveyor
 
 import (
 	"fmt"
-	"log"
-	"os"
 	"time"
 
 	"github.com/remind101/conveyor/builder"
 	"github.com/remind101/pkg/reporter"
-
-	"golang.org/x/net/context"
 )
 
 const (
 	// DefaultTimeout is the default amount of time to wait for a build
 	// to complete before cancelling it.
 	DefaultTimeout = 20 * time.Minute
+
+	// DefaultWorkers is the default number of workers to start.
+	DefaultWorkers = 100
 )
+
+// Options provided when initializing a new Conveyor instance.
+type Options struct {
+	// LogFactory used to generate a builder.Logger.
+	LogFactory builder.LogFactory
+
+	// Reporter used to reporter errors.
+	Reporter reporter.Reporter
+
+	// The backend used to perform the builds.
+	Builder builder.Builder
+
+	// Number of workers to spin up.
+	Workers int
+}
 
 // Conveyor serves as a builder.
 type Conveyor struct {
-	Builder    builder.Builder
-	LogFactory builder.LogFactory
 	BuildQueue
-
-	// A Reporter to use to report errors.
-	Reporter reporter.Reporter
-
-	// Timeout controls how long to wait before canceling a build. A timeout
-	// of 0 means no timeout.
-	Timeout time.Duration
+	workers []*Worker
+	builder builder.Builder
 }
 
 // New returns a new Conveyor instance.
-func New(b builder.Builder) *Conveyor {
-	c := &Conveyor{
-		Builder:    builder.WithCancel(builder.CloseWriter(b)),
-		BuildQueue: newBuildQueue(100),
-		Timeout:    DefaultTimeout,
+func New(options Options) *Conveyor {
+	q := newBuildQueue(100)
+	b := builder.WithCancel(builder.CloseWriter(options.Builder))
+
+	numWorkers := options.Workers
+	if numWorkers == 0 {
+		numWorkers = DefaultWorkers
 	}
 
-	go c.start()
+	var workers []*Worker
+	for i := 0; i < numWorkers; i++ {
+		workers = append(workers, &Worker{
+			Builder: &Builder{
+				Builder:  b,
+				Reporter: options.Reporter,
+				Timeout:  DefaultTimeout,
+			},
+			BuildQueue: q,
+		})
+	}
+
+	c := &Conveyor{
+		BuildQueue: q,
+		workers:    workers,
+		builder:    b,
+	}
+
+	c.Start()
 
 	return c
 }
 
-func (c *Conveyor) start() {
-	for {
-		ctx, options, err := c.Pop()
-		if err != nil {
-			log.Println(err)
-		}
-
-		_, err = c.Build(ctx, options)
-		if err != nil {
-			log.Println(err)
-		}
+// Start each worker in it's own goroutine.
+func (c *Conveyor) Start() {
+	for _, w := range c.workers {
+		go w.Start()
 	}
-}
-
-// Build builds the image.
-func (c *Conveyor) Build(ctx context.Context, opts builder.BuildOptions) (image string, err error) {
-	w, err := c.newLogger(opts)
-	if err != nil {
-		return "", err
-	}
-
-	log.Printf("Starting build: repository=%s branch=%s sha=%s",
-		opts.Repository,
-		opts.Branch,
-		opts.Sha,
-	)
-
-	// Embed the reporter in the context.Context.
-	ctx = reporter.WithReporter(ctx, c.reporter())
-
-	if c.Timeout != 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, c.Timeout)
-		defer cancel() // Release resources.
-	}
-
-	reporter.AddContext(ctx, "options", opts)
-	defer reporter.Monitor(ctx)
-
-	defer func() {
-		if err != nil {
-			reporter.Report(ctx, err)
-		}
-	}()
-
-	image, err = c.Builder.Build(ctx, w, opts)
-	return
 }
 
 func (c *Conveyor) Cancel() error {
-	if b, ok := c.Builder.(*builder.CancelBuilder); ok {
+	if b, ok := c.builder.(*builder.CancelBuilder); ok {
 		return b.Cancel()
 	}
 
 	return fmt.Errorf("Builder does not support Cancel()")
-}
-
-func (c *Conveyor) newLogger(opts builder.BuildOptions) (builder.Logger, error) {
-	if c.LogFactory == nil {
-		return builder.StdoutLogger(opts)
-	}
-
-	return c.LogFactory(opts)
-}
-
-func (c *Conveyor) reporter() reporter.Reporter {
-	if c.Reporter == nil {
-		return reporter.ReporterFunc(func(ctx context.Context, err error) error {
-			fmt.Fprintf(os.Stderr, "reporting err: %v\n", err)
-			return nil
-		})
-	}
-
-	return c.Reporter
 }

--- a/conveyor.go
+++ b/conveyor.go
@@ -57,14 +57,16 @@ func New(options Options) *Conveyor {
 		LogFactory: options.LogFactory,
 	})
 
-	c := &Conveyor{
+	return &Conveyor{
 		BuildQueue: q,
 		Workers:    workers,
 		builder:    b,
 	}
+}
 
-	// Start the workers.
-	c.Workers.Start()
-
+// NewAndStart builds a new Conveyor instance and starts the workers.
+func NewAndStart(options Options) *Conveyor {
+	c := New(options)
+	c.Start()
 	return c
 }

--- a/conveyor_test.go
+++ b/conveyor_test.go
@@ -1,0 +1,34 @@
+package conveyor
+
+import (
+	"io"
+
+	"github.com/remind101/conveyor/builder"
+	"github.com/stretchr/testify/mock"
+	"golang.org/x/net/context"
+)
+
+// mockBuilder is a mock implementation of the builder.Builder interface.
+type mockBuilder struct {
+	mock.Mock
+}
+
+func (b *mockBuilder) Build(ctx context.Context, w io.Writer, options builder.BuildOptions) (string, error) {
+	args := b.Called(w, options)
+	return args.String(0), args.Error(1)
+}
+
+// mockBuildQueue is an implementation of the BuildQueue interface for testing.
+type mockBuildQueue struct {
+	mock.Mock
+}
+
+func (q *mockBuildQueue) Push(ctx context.Context, options builder.BuildOptions) error {
+	args := q.Called(options)
+	return args.Error(0)
+}
+
+func (q *mockBuildQueue) Subscribe() chan BuildRequest {
+	args := q.Called()
+	return args.Get(0).(chan BuildRequest)
+}

--- a/conveyor_test.go
+++ b/conveyor_test.go
@@ -18,6 +18,16 @@ func (b *mockBuilder) Build(ctx context.Context, w io.Writer, options builder.Bu
 	return args.String(0), args.Error(1)
 }
 
+// mockCancelBuilder is a mockBuilder that responds to Cancel.
+type mockCancelBuilder struct {
+	mockBuilder
+}
+
+func (b *mockCancelBuilder) Cancel() error {
+	args := b.Called()
+	return args.Error(0)
+}
+
 // mockBuildQueue is an implementation of the BuildQueue interface for testing.
 type mockBuildQueue struct {
 	mock.Mock

--- a/queue.go
+++ b/queue.go
@@ -1,0 +1,46 @@
+package conveyor
+
+import (
+	"github.com/remind101/conveyor/builder"
+	"golang.org/x/net/context"
+)
+
+// BuildQueue represents a queue that can push build requests onto a queue, and
+// also pop requests from the queue.
+type BuildQueue interface {
+	// Push pushes the build request onto the queue.
+	Push(context.Context, builder.BuildOptions) error
+
+	// Pop returns the next build request from the queue.
+	Pop() (context.Context, builder.BuildOptions, error)
+}
+
+type buildRequest struct {
+	ctx     context.Context
+	options builder.BuildOptions
+}
+
+// buildQueue is an implementation of the BuildQueue interface that is in memory
+// using a channel.
+type buildQueue struct {
+	queue chan buildRequest
+}
+
+func newBuildQueue(buffer int) *buildQueue {
+	return &buildQueue{
+		queue: make(chan buildRequest, buffer),
+	}
+}
+
+func (q *buildQueue) Push(ctx context.Context, options builder.BuildOptions) error {
+	q.queue <- buildRequest{
+		ctx:     ctx,
+		options: options,
+	}
+	return nil
+}
+
+func (q *buildQueue) Pop() (context.Context, builder.BuildOptions, error) {
+	req := <-q.queue
+	return req.ctx, req.options, nil
+}

--- a/queue_test.go
+++ b/queue_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestBuildQueue(t *testing.T) {
 	q := &buildQueue{
-		queue: make(chan buildRequest, 1),
+		queue: make(chan BuildRequest, 1),
 	}
 
 	background := context.Background()
@@ -19,7 +19,7 @@ func TestBuildQueue(t *testing.T) {
 	err := q.Push(background, options)
 	assert.NoError(t, err)
 
-	ctx, got, err := q.Pop()
-	assert.Equal(t, got, options)
-	assert.Equal(t, ctx, background)
+	req := <-q.Subscribe()
+	assert.Equal(t, req.BuildOptions, options)
+	assert.Equal(t, req.Ctx, background)
 }

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,0 +1,25 @@
+package conveyor
+
+import (
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/remind101/conveyor/builder"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildQueue(t *testing.T) {
+	q := &buildQueue{
+		queue: make(chan buildRequest, 1),
+	}
+
+	background := context.Background()
+	options := builder.BuildOptions{}
+	err := q.Push(background, options)
+	assert.NoError(t, err)
+
+	ctx, got, err := q.Pop()
+	assert.Equal(t, got, options)
+	assert.Equal(t, ctx, background)
+}

--- a/server.go
+++ b/server.go
@@ -78,7 +78,8 @@ func (s *Server) Push(w http.ResponseWriter, r *http.Request) {
 		NoCache:    noCache(event.HeadCommit.Message),
 	}
 
-	if err := s.EnqueueBuild(ctx, opts); err != nil {
+	// Enqueue the build
+	if err := s.Conveyor.Push(ctx, opts); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server.go
+++ b/server.go
@@ -18,15 +18,15 @@ import (
 // Server implements the http.Handler interface for serving build requests via
 // GitHub webhooks.
 type Server struct {
-	*Conveyor
+	Queue BuildQueue
 
 	// mux contains the routes.
 	mux http.Handler
 }
 
 // NewServer returns a new Server instance
-func NewServer(c *Conveyor) *Server {
-	s := &Server{Conveyor: c}
+func NewServer(q BuildQueue) *Server {
+	s := &Server{Queue: q}
 
 	r := hookshot.NewRouter()
 	r.HandleFunc("ping", s.Ping)
@@ -79,7 +79,7 @@ func (s *Server) Push(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Enqueue the build
-	if err := s.Conveyor.Push(ctx, opts); err != nil {
+	if err := s.Queue.Push(ctx, opts); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -6,11 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/context"
-
 	"github.com/remind101/conveyor/builder"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestServer_Ping(t *testing.T) {
@@ -110,19 +107,4 @@ func TestNoCache(t *testing.T) {
 			t.Fatalf("noCache(%q) => %v; want %v", tt.in, got, want)
 		}
 	}
-}
-
-// mockBuildQueue is an implementation of the BuildQueue interface for testing.
-type mockBuildQueue struct {
-	mock.Mock
-}
-
-func (q *mockBuildQueue) Push(ctx context.Context, options builder.BuildOptions) error {
-	args := q.Called(options)
-	return args.Error(0)
-}
-
-func (q *mockBuildQueue) Subscribe() chan BuildRequest {
-	args := q.Called()
-	return args.Get(0).(chan BuildRequest)
 }

--- a/server_test.go
+++ b/server_test.go
@@ -122,7 +122,7 @@ func (q *mockBuildQueue) Push(ctx context.Context, options builder.BuildOptions)
 	return args.Error(0)
 }
 
-func (q *mockBuildQueue) Pop() (context.Context, builder.BuildOptions, error) {
+func (q *mockBuildQueue) Subscribe() chan BuildRequest {
 	args := q.Called()
-	return context.Background(), args.Get(0).(builder.BuildOptions), args.Error(1)
+	return args.Get(0).(chan BuildRequest)
 }

--- a/tests/conveyor_test.go
+++ b/tests/conveyor_test.go
@@ -66,7 +66,7 @@ func newConveyor(t *testing.T, w io.Writer) *conveyor.Conveyor {
 	}
 	b.DryRun = true
 
-	return conveyor.New(conveyor.Options{
+	return conveyor.NewAndStart(conveyor.Options{
 		LogFactory: func(builder.BuildOptions) (builder.Logger, error) {
 			return builder.NewLogger(w), nil
 		},

--- a/tests/conveyor_test.go
+++ b/tests/conveyor_test.go
@@ -17,11 +17,14 @@ import (
 func TestConveyor(t *testing.T) {
 	checkDocker(t)
 
-	c := newConveyor(t)
 	w := new(bytes.Buffer)
+	c := newConveyor(t)
+	c.LogFactory = func(builder.BuildOptions) (builder.Logger, error) {
+		return builder.NewLogger(w), nil
+	}
 
 	ctx := context.Background()
-	if _, err := c.Build(ctx, w, builder.BuildOptions{
+	if _, err := c.Build(ctx, builder.BuildOptions{
 		Repository: "remind101/acme-inc",
 		Branch:     "master",
 		Sha:        "827fecd2d36ebeaa2fd05aa8ef3eed1e56a8cd57",
@@ -39,13 +42,16 @@ func TestConveyor(t *testing.T) {
 func TestConveyor_WithTimeout(t *testing.T) {
 	checkDocker(t)
 
-	c := newConveyor(t)
 	w := new(bytes.Buffer)
+	c := newConveyor(t)
+	c.LogFactory = func(builder.BuildOptions) (builder.Logger, error) {
+		return builder.NewLogger(w), nil
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	if _, err := c.Build(ctx, w, builder.BuildOptions{
+	if _, err := c.Build(ctx, builder.BuildOptions{
 		Repository: "remind101/acme-inc",
 		Branch:     "master",
 		Sha:        "827fecd2d36ebeaa2fd05aa8ef3eed1e56a8cd57",

--- a/worker.go
+++ b/worker.go
@@ -1,0 +1,111 @@
+package conveyor
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/remind101/conveyor/builder"
+	"github.com/remind101/pkg/reporter"
+)
+
+// Worker pulls jobs off of a BuildQueue and performs the build.
+type Worker struct {
+	// Builder to use to build.
+	builder.Builder
+
+	// LogFactory to use to build a builder.Logger
+	LogFactory builder.LogFactory
+
+	// Queue to pull jobs from.
+	BuildQueue
+}
+
+// Start starts the worker consuming for the BuildQueue.
+func (w *Worker) Start() {
+	for {
+		ctx, options, err := w.Pop()
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		logger, err := w.newLogger(options)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+
+		_, err = w.Build(ctx, logger, options)
+		if err != nil {
+			log.Println(err)
+			continue
+		}
+	}
+}
+
+func (w *Worker) newLogger(opts builder.BuildOptions) (builder.Logger, error) {
+	if w.LogFactory == nil {
+		return builder.StdoutLogger(opts)
+	}
+
+	return w.LogFactory(opts)
+}
+
+// Builder is an implementation of the builder.Builder interface that adds
+// timeouts and error reporting.
+type Builder struct {
+	builder.Builder
+
+	// A Reporter to use to report errors.
+	Reporter reporter.Reporter
+
+	// Timeout controls how long to wait before canceling a build. A timeout
+	// of 0 means no timeout.
+	Timeout time.Duration
+}
+
+// Build builds the image.
+func (b *Builder) Build(ctx context.Context, w io.Writer, opts builder.BuildOptions) (image string, err error) {
+	log.Printf("Starting build: repository=%s branch=%s sha=%s",
+		opts.Repository,
+		opts.Branch,
+		opts.Sha,
+	)
+
+	// Embed the reporter in the context.Context.
+	ctx = reporter.WithReporter(ctx, b.reporter())
+
+	if b.Timeout != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
+		defer cancel() // Release resources.
+	}
+
+	reporter.AddContext(ctx, "options", opts)
+	defer reporter.Monitor(ctx)
+
+	defer func() {
+		if err != nil {
+			reporter.Report(ctx, err)
+		}
+	}()
+
+	image, err = b.Builder.Build(ctx, w, opts)
+	return
+}
+
+func (b *Builder) reporter() reporter.Reporter {
+	if b.Reporter == nil {
+		return reporter.ReporterFunc(func(ctx context.Context, err error) error {
+			fmt.Fprintf(os.Stderr, "reporting err: %v\n", err)
+			return nil
+		})
+	}
+
+	return b.Reporter
+}

--- a/worker.go
+++ b/worker.go
@@ -16,32 +16,69 @@ type Worker struct {
 
 	// Queue to pull jobs from.
 	buildRequests chan BuildRequest
+
+	// Channel used to request a shutdown.
+	shutdown chan struct{}
+
+	// Channel that is sent on when all builds are finished.
+	done chan error
 }
 
 // NewWorker returns a new Worker instance and subscribes to receive build
 // requests from the BuildQueue.
 func NewWorker(q BuildQueue, b builder.Builder) *Worker {
 	return &Worker{
-		Builder:       b,
+		Builder:       builder.WithCancel(b),
 		buildRequests: q.Subscribe(),
+		shutdown:      make(chan struct{}),
+		done:          make(chan error),
 	}
 }
 
 // Start starts the worker consuming for the BuildQueue.
 func (w *Worker) Start() {
-	for req := range w.buildRequests {
-		logger, err := w.newLogger(req.BuildOptions)
-		if err != nil {
-			log.Println(err)
+	for {
+		select {
+		case <-w.shutdown:
+			var err error
+			if b, ok := w.Builder.(interface {
+				Cancel() error
+			}); ok {
+				err = b.Cancel()
+			}
+
+			w.done <- err
+			break
+		case req, ok := <-w.buildRequests:
+			if !ok {
+				break
+			}
+
+			logger, err := w.newLogger(req.BuildOptions)
+			if err != nil {
+				log.Println(err)
+				continue
+			}
+
+			_, err = w.Build(req.Ctx, logger, req.BuildOptions)
+			if err != nil {
+				log.Println(err)
+				continue
+			}
+
 			continue
 		}
 
-		_, err = w.Build(req.Ctx, logger, req.BuildOptions)
-		if err != nil {
-			log.Println(err)
-			continue
-		}
+		break
 	}
+}
+
+// Shutdown stops this worker for processing any build requests. If the Builder
+// supports the Cancel method, this function will block until all currently
+// processesing builds have been canceled.
+func (w *Worker) Shutdown() error {
+	close(w.shutdown)
+	return <-w.done
 }
 
 func (w *Worker) newLogger(opts builder.BuildOptions) (builder.Logger, error) {

--- a/worker.go
+++ b/worker.go
@@ -1,16 +1,9 @@
 package conveyor
 
 import (
-	"fmt"
-	"io"
 	"log"
-	"os"
-	"time"
-
-	"golang.org/x/net/context"
 
 	"github.com/remind101/conveyor/builder"
-	"github.com/remind101/pkg/reporter"
 )
 
 // Worker pulls jobs off of a BuildQueue and performs the build.
@@ -54,58 +47,4 @@ func (w *Worker) newLogger(opts builder.BuildOptions) (builder.Logger, error) {
 	}
 
 	return w.LogFactory(opts)
-}
-
-// Builder is an implementation of the builder.Builder interface that adds
-// timeouts and error reporting.
-type Builder struct {
-	builder.Builder
-
-	// A Reporter to use to report errors.
-	Reporter reporter.Reporter
-
-	// Timeout controls how long to wait before canceling a build. A timeout
-	// of 0 means no timeout.
-	Timeout time.Duration
-}
-
-// Build builds the image.
-func (b *Builder) Build(ctx context.Context, w io.Writer, opts builder.BuildOptions) (image string, err error) {
-	log.Printf("Starting build: repository=%s branch=%s sha=%s",
-		opts.Repository,
-		opts.Branch,
-		opts.Sha,
-	)
-
-	// Embed the reporter in the context.Context.
-	ctx = reporter.WithReporter(ctx, b.reporter())
-
-	if b.Timeout != 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.Timeout)
-		defer cancel() // Release resources.
-	}
-
-	reporter.AddContext(ctx, "options", opts)
-	defer reporter.Monitor(ctx)
-
-	defer func() {
-		if err != nil {
-			reporter.Report(ctx, err)
-		}
-	}()
-
-	image, err = b.Builder.Build(ctx, w, opts)
-	return
-}
-
-func (b *Builder) reporter() reporter.Reporter {
-	if b.Reporter == nil {
-		return reporter.ReporterFunc(func(ctx context.Context, err error) error {
-			fmt.Fprintf(os.Stderr, "reporting err: %v\n", err)
-			return nil
-		})
-	}
-
-	return b.Reporter
 }

--- a/worker.go
+++ b/worker.go
@@ -10,19 +10,11 @@ import (
 // Workers is a collection of workers.
 type Workers []*Worker
 
-// Start starts all of the workers in the pool.
+// Start starts all of the workers in the pool in their own goroutine.
 func (w Workers) Start() {
-	var wg sync.WaitGroup
-
 	for _, worker := range w {
-		wg.Add(1)
-		go func(worker *Worker) {
-			defer wg.Done()
-			worker.Start()
-		}(worker)
+		go worker.Start()
 	}
-
-	wg.Wait()
 }
 
 // Shutdown shuts down all of the workers in the pool.

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,12 +1,14 @@
 package conveyor
 
 import (
+	"errors"
 	"io/ioutil"
 	"testing"
 
 	"golang.org/x/net/context"
 
 	"github.com/remind101/conveyor/builder"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestWorker(t *testing.T) {
@@ -37,4 +39,91 @@ func TestWorker(t *testing.T) {
 	close(q)
 
 	<-done
+}
+
+func TestWorker_Shutdown(t *testing.T) {
+	l := builder.NewLogger(ioutil.Discard)
+	b := new(mockBuilder)
+	f := func(options builder.BuildOptions) (builder.Logger, error) {
+		return l, nil
+	}
+	q := make(chan BuildRequest, 1)
+	w := &Worker{
+		Builder:       b,
+		LogFactory:    f,
+		buildRequests: q,
+		shutdown:      make(chan struct{}),
+		done:          make(chan error),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		w.Start()
+		close(done)
+	}()
+
+	err := w.Shutdown()
+
+	<-done
+
+	assert.NoError(t, err)
+}
+
+func TestWorker_Shutdown_Cancel(t *testing.T) {
+	l := builder.NewLogger(ioutil.Discard)
+	b := new(mockCancelBuilder)
+	f := func(options builder.BuildOptions) (builder.Logger, error) {
+		return l, nil
+	}
+	q := make(chan BuildRequest, 1)
+	w := &Worker{
+		Builder:       b,
+		LogFactory:    f,
+		buildRequests: q,
+		shutdown:      make(chan struct{}),
+		done:          make(chan error),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		w.Start()
+		close(done)
+	}()
+
+	b.On("Cancel").Return(nil)
+	err := w.Shutdown()
+
+	<-done
+
+	assert.NoError(t, err)
+}
+
+func TestWorker_Shutdown_Cancel_Error(t *testing.T) {
+	l := builder.NewLogger(ioutil.Discard)
+	b := new(mockCancelBuilder)
+	f := func(options builder.BuildOptions) (builder.Logger, error) {
+		return l, nil
+	}
+	q := make(chan BuildRequest, 1)
+	w := &Worker{
+		Builder:       b,
+		LogFactory:    f,
+		buildRequests: q,
+		shutdown:      make(chan struct{}),
+		done:          make(chan error),
+	}
+
+	done := make(chan struct{})
+	go func() {
+		w.Start()
+		close(done)
+	}()
+
+	boom := errors.New("Failed to cancel")
+	b.On("Cancel").Return(boom)
+	err := w.Shutdown()
+
+	<-done
+
+	assert.Equal(t, boom, err)
 }

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,0 +1,40 @@
+package conveyor
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/remind101/conveyor/builder"
+)
+
+func TestWorker(t *testing.T) {
+	l := builder.NewLogger(ioutil.Discard)
+	b := new(mockBuilder)
+	f := func(options builder.BuildOptions) (builder.Logger, error) {
+		return l, nil
+	}
+	q := make(chan BuildRequest, 1)
+	w := &Worker{
+		Builder:       b,
+		LogFactory:    f,
+		buildRequests: q,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		w.Start()
+		close(done)
+	}()
+
+	b.On("Build", l, builder.BuildOptions{}).Return("", nil)
+
+	q <- BuildRequest{
+		Ctx:          context.Background(),
+		BuildOptions: builder.BuildOptions{},
+	}
+	close(q)
+
+	<-done
+}


### PR DESCRIPTION
This is primarily an internal refactoring to support multiple scale out methods:

1. The first scale out method is basically what we're doing now: you run `conveyor server` and all builds are performed in goroutines talking to a single docker daemon. Scaling out can be achieved using something like docker swarm to scale out the docker API.
2. The second scale out method is via a BuildQueue. This will allow you to provide a queue implementation (sqs will probably be the first), allowing you to run a separate `conveyor worker` subcommand. The idea here is that `conveyor server` pushes build requests into a queue, and then individual workers pull jobs off and run the build with their local docker daemon.

The first method is probably the easiest, but I think using an actual queue and multiple worker nodes might be more robust in the long run. This at least gives users a couple options.