### PR TITLE
Add worker subcommand.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,3 @@ WORKDIR /go/src/github.com/remind101/conveyor
 RUN godep go install ./cmd/conveyor
 
 ENTRYPOINT ["/go/bin/conveyor"]
-
-CMD ["server"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Conveyor supports two methods to scale out to multiple machines.
 
 ### Docker Swarm
 
-The first method to scale out Conveyor is to scale out using [Docker Swarm](https://github.com/docker/swarm). Using this method, Conveyor runs it's builds across a cluster of Docker daemons. The advantage of using this method is that you don't need to provide a `queue` flag since Conveyor can use an in memory queue.
+The first method to scale out Conveyor is to scale out using [Docker Swarm](https://github.com/docker/swarm). Using this method, Conveyor runs its builds across a cluster of Docker daemons. The advantage of using this method is that you don't need to provide a `queue` flag since Conveyor can use an in memory queue.
 
 ### Queue
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,21 @@ By default, conveyor will pull the last built image for the branch. This isn't a
 
 ## Scale Out
 
-Conveyor only needs to talk to the docker daemon API. The easiest way to scale out is to scale out Docker using [Docker Swarm](https://github.com/docker/swarm).
+Conveyor supports two methods to scale out to multiple machines.
+
+### Docker Swarm
+
+The first method to scale out Conveyor is to scale out using [Docker Swarm](https://github.com/docker/swarm). Using this method, Conveyor runs it's builds across a cluster of Docker daemons. The advantage of using this method is that you don't need to provide a `queue` flag since Conveyor can use an in memory queue.
+
+### Queue
+
+The recommended way to scale out is to scale out using a build queue. Using this method, you run the `conveyor worker` subcommand on a machine that hosts a local Docker daemon. The worker process will pull build requests off of the queue and perform the build. The `conveyor server` command can then run completely separate from the worker nodes.
+
+![](https://dl.dropboxusercontent.com/u/1906634/GitHub/Conveyor%20-%20Split.png)
+
+Conveyor currently supports the following build queues:
+
+1. SQS
 
 ## API (Soon)
 

--- a/cmd/conveyor/factories.go
+++ b/cmd/conveyor/factories.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/codegangsta/cli"
+	"github.com/ejholmes/hookshot"
+	"github.com/remind101/conveyor"
+	"github.com/remind101/conveyor/builder"
+	"github.com/remind101/conveyor/builder/docker"
+	"github.com/remind101/pkg/reporter"
+	"github.com/remind101/pkg/reporter/hb2"
+)
+
+func newBuildQueue(c *cli.Context) conveyor.BuildQueue {
+	return conveyor.NewBuildQueue(100)
+}
+
+func newServer(q conveyor.BuildQueue, c *cli.Context) http.Handler {
+	return hookshot.Authorize(
+		conveyor.NewServer(q),
+		c.String("github.secret"),
+	)
+}
+
+func newBuilder(c *cli.Context) builder.Builder {
+	db, err := docker.NewBuilderFromEnv()
+	if err != nil {
+		must(err)
+	}
+	db.DryRun = c.Bool("dry")
+	db.Image = c.String("builder.image")
+
+	g := builder.NewGitHubClient(c.String("github.token"))
+	b := conveyor.NewBuilder(builder.UpdateGitHubCommitStatus(db, g))
+	b.Reporter = newReporter(c)
+	return b
+}
+
+func newReporter(c *cli.Context) reporter.Reporter {
+	u, err := url.Parse(c.String("reporter"))
+	if err != nil {
+		must(err)
+	}
+
+	switch u.Scheme {
+	case "hb":
+		q := u.Query()
+		return hb2.NewReporter(hb2.Config{
+			ApiKey:      q.Get("key"),
+			Environment: q.Get("environment"),
+		})
+	default:
+		must(err)
+		return nil
+	}
+}
+
+func newLogFactory(c *cli.Context) builder.LogFactory {
+	u, err := url.Parse(c.String("logger"))
+	if err != nil {
+		must(err)
+	}
+
+	switch u.Scheme {
+	case "s3":
+		f, err := builder.S3Logger(u.Host)
+		if err != nil {
+			must(err)
+		}
+		return f
+	default:
+		must(err)
+		return nil
+	}
+}

--- a/cmd/conveyor/main.go
+++ b/cmd/conveyor/main.go
@@ -58,6 +58,7 @@ func mainAction(c *cli.Context) {
 func must(err error) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/conveyor/server.go
+++ b/cmd/conveyor/server.go
@@ -19,12 +19,6 @@ var serverFlags = []cli.Flag{
 		EnvVar: "PORT",
 	},
 	cli.StringFlag{
-		Name:   "github.token",
-		Value:  "",
-		Usage:  "GitHub API token to use when updating commit statuses on repositories.",
-		EnvVar: "GITHUB_TOKEN",
-	},
-	cli.StringFlag{
 		Name:   "github.secret",
 		Value:  "",
 		Usage:  "Shared secret used by GitHub to sign webhook payloads. This secret will be used to verify that the request came from GitHub.",

--- a/cmd/conveyor/server.go
+++ b/cmd/conveyor/server.go
@@ -1,91 +1,66 @@
 package main
 
 import (
-	"log"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"github.com/codegangsta/cli"
-	dockerbuilder "github.com/remind101/conveyor/builder/docker"
+	"github.com/remind101/conveyor"
 )
 
-var cmdServer = cli.Command{
-	Name:   "server",
-	Usage:  "Run an http server to build Docker images whenever a push event happens on GitHub",
-	Action: runServer,
-	Flags: []cli.Flag{
-		cli.StringFlag{
-			Name:   "port",
-			Value:  "8080",
-			Usage:  "Port to run the server on",
-			EnvVar: "PORT",
-		},
-		cli.StringFlag{
-			Name:   "github.token",
-			Value:  "",
-			Usage:  "GitHub API token to use when updating commit statuses on repositories.",
-			EnvVar: "GITHUB_TOKEN",
-		},
-		cli.StringFlag{
-			Name:   "github.secret",
-			Value:  "",
-			Usage:  "Shared secret used by GitHub to sign webhook payloads. This secret will be used to verify that the request came from GitHub.",
-			EnvVar: "GITHUB_SECRET",
-		},
-		cli.BoolFlag{
-			Name:   "dry",
-			Usage:  "Enable dry run mode.",
-			EnvVar: "DRY",
-		},
-		cli.StringFlag{
-			Name:   "builder.image",
-			Value:  dockerbuilder.DefaultBuilderImage,
-			Usage:  "A docker image to use to perform the build.",
-			EnvVar: "BUILDER_IMAGE",
-		},
-		cli.StringFlag{
-			Name:   "logger",
-			Value:  "stdout://",
-			Usage:  "The logger to use. Available options are `stdout://`, or `s3://bucket`.",
-			EnvVar: "LOGGER",
-		},
-		cli.StringFlag{
-			Name:   "reporter",
-			Value:  "",
-			Usage:  "The reporter to use to report errors. Available options are `hb://api.honeybadger.io?key=<key>&environment=<environment>",
-			EnvVar: "REPORTER",
-		},
+// flags for the http server.
+var serverFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:   "port",
+		Value:  "8080",
+		Usage:  "Port to run the server on",
+		EnvVar: "PORT",
+	},
+	cli.StringFlag{
+		Name:   "github.token",
+		Value:  "",
+		Usage:  "GitHub API token to use when updating commit statuses on repositories.",
+		EnvVar: "GITHUB_TOKEN",
+	},
+	cli.StringFlag{
+		Name:   "github.secret",
+		Value:  "",
+		Usage:  "Shared secret used by GitHub to sign webhook payloads. This secret will be used to verify that the request came from GitHub.",
+		EnvVar: "GITHUB_SECRET",
 	},
 }
 
-func runServer(c *cli.Context) {
-	port := c.String("port")
+var cmdServer = cli.Command{
+	Name:   "server",
+	Usage:  "Run only the http server component.",
+	Action: serverAction,
+	Flags:  append(sharedFlags, serverFlags...),
+}
 
-	b, err := newConveyor(c)
-	if err != nil {
-		log.Fatal(err)
-	}
+func serverAction(c *cli.Context) {
+	q := newBuildQueue(c)
 
+	runServer(q, c)
+}
+
+func runServer(q conveyor.BuildQueue, c *cli.Context) error {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		sig := <-quit
 
-		log.Printf("Signal %d received. Shutting down.\n", sig)
-		if err := b.Shutdown(); err != nil {
-			log.Fatal(err)
-		}
-		os.Exit(0)
+	port := c.String("port")
+	info("Starting server on %s\n", port)
+
+	errCh := make(chan error)
+	go func() {
+		errCh <- http.ListenAndServe(":"+port, newServer(q, c))
 	}()
 
-	s, err := newServer(c, b)
-	if err != nil {
-		log.Fatal(err)
+	select {
+	case err := <-errCh:
+		return err
+	case <-quit:
+		return nil
 	}
-
-	log.Println("Listening on " + port)
-	b.Start()
-	log.Fatal(http.ListenAndServe(":"+port, s))
 }

--- a/cmd/conveyor/worker.go
+++ b/cmd/conveyor/worker.go
@@ -13,6 +13,12 @@ import (
 
 // flags for the worker.
 var workerFlags = []cli.Flag{
+	cli.StringFlag{
+		Name:   "github.token",
+		Value:  "",
+		Usage:  "GitHub API token to use when updating commit statuses on repositories.",
+		EnvVar: "GITHUB_TOKEN",
+	},
 	cli.BoolFlag{
 		Name:   "dry",
 		Usage:  "Enable dry run mode.",

--- a/cmd/conveyor/worker.go
+++ b/cmd/conveyor/worker.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+
+	"github.com/codegangsta/cli"
+	"github.com/remind101/conveyor"
+	"github.com/remind101/conveyor/builder/docker"
+)
+
+// flags for the worker.
+var workerFlags = []cli.Flag{
+	cli.BoolFlag{
+		Name:   "dry",
+		Usage:  "Enable dry run mode.",
+		EnvVar: "DRY",
+	},
+	cli.StringFlag{
+		Name:   "builder.image",
+		Value:  docker.DefaultBuilderImage,
+		Usage:  "A docker image to use to perform the build.",
+		EnvVar: "BUILDER_IMAGE",
+	},
+	cli.StringFlag{
+		Name:   "logger",
+		Value:  "stdout://",
+		Usage:  "The logger to use. Available options are `stdout://`, or `s3://bucket`.",
+		EnvVar: "LOGGER",
+	},
+	cli.StringFlag{
+		Name:   "reporter",
+		Value:  "",
+		Usage:  "The reporter to use to report errors. Available options are `hb://api.honeybadger.io?key=<key>&environment=<environment>",
+		EnvVar: "REPORTER",
+	},
+	cli.IntFlag{
+		Name:   "workers",
+		Value:  runtime.NumCPU(),
+		Usage:  "Number of workers in goroutines to start.",
+		EnvVar: "WORKERS",
+	},
+}
+
+var cmdWorker = cli.Command{
+	Name:   "worker",
+	Usage:  "Run a set of workers.",
+	Action: workerAction,
+	Flags:  append(sharedFlags, workerFlags...),
+}
+
+func workerAction(c *cli.Context) {
+	q := newBuildQueue(c)
+
+	if err := runWorker(q, c); err != nil {
+		must(err)
+	}
+}
+
+func runWorker(q conveyor.BuildQueue, c *cli.Context) error {
+	numWorkers := c.Int("workers")
+
+	info("Starting %d workers\n", numWorkers)
+
+	workers := conveyor.NewWorkerPool(numWorkers, conveyor.WorkerOptions{
+		Builder:    newBuilder(c),
+		LogFactory: newLogFactory(c),
+		BuildQueue: q,
+	})
+
+	workers.Start()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+	sig := <-quit
+
+	info("Signal %d received. Shutting down workers.\n", sig)
+	return workers.Shutdown()
+}

--- a/queue.go
+++ b/queue.go
@@ -34,6 +34,11 @@ func newBuildQueue(buffer int) *buildQueue {
 	}
 }
 
+// NewBuildQueue returns a new in memory BuildQueue.
+func NewBuildQueue(buffer int) BuildQueue {
+	return newBuildQueue(buffer)
+}
+
 func (q *buildQueue) Push(ctx context.Context, options builder.BuildOptions) error {
 	q.queue <- BuildRequest{
 		Ctx:          ctx,


### PR DESCRIPTION
This is just a little prep for the SQS BuildQueue implementation. Conveyor now has two subcommands:

1. `conveyor server`: Only runs the http server that enqueues build requests.
2. `conveyor worker`: Runs a configurable number of workers (defaulting to runtime.NumCPU) that will pop jobs from the build queue and perform the build using a docker daemon.

Invoking `conveyor` without any subcommands will yield the previous behavior and start both the server and the workers.

There's also a `--queue` flag now, but the only option available is `memory://`.

After the SQS implementation is added, this will allow you to split Conveyor apart using a setup like this:

![](https://dl.dropboxusercontent.com/u/1906634/GitHub/Conveyor%20-%20Split.png)