### PR TITLE
Use Docker repo:tag format for build command.

### DIFF
--- a/cmd/conveyor/factories.go
+++ b/cmd/conveyor/factories.go
@@ -91,7 +91,7 @@ func newSlackServer(q conveyor.BuildQueue, c *cli.Context) http.Handler {
 		),
 	)
 	r.MatchText(
-		regexp.MustCompile(`build (?P<owner>\S+?)/(?P<repo>\S+)@(?P<branch>\S+)`),
+		slack.BuildRegexp,
 		slack.NewBuild(
 			client,
 			q,

--- a/slack/build.go
+++ b/slack/build.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"text/template"
 
 	"code.google.com/p/go-uuid/uuid"
@@ -19,6 +20,9 @@ var newID = uuid.New
 type branchResolver interface {
 	resolveBranch(owner, repo, branch string) (sha string, err error)
 }
+
+// A regex for matching build commands.
+var BuildRegexp = regexp.MustCompile(`build (?P<owner>\S+?)/(?P<repo>\S+)[@:#](?P<branch>\S+)`)
 
 // Build is a slash.Handler that will trigger a conveyor build.
 type Build struct {
@@ -69,7 +73,7 @@ func (b *Build) build(ctx context.Context, r slash.Responder, owner, repo, branc
 		return r.Respond(slash.Reply(err.Error()))
 	}
 
-	return r.Respond(slash.Reply(fmt.Sprintf("Building %s@%s: %s", fullRepo, branch, url)))
+	return r.Respond(slash.Reply(fmt.Sprintf("Building %s:%s %s", fullRepo, branch, url)))
 }
 
 func (b *Build) url(opts builder.BuildOptions) (string, error) {

--- a/slack/build_test.go
+++ b/slack/build_test.go
@@ -47,7 +47,25 @@ func TestBuild(t *testing.T) {
 	assert.NoError(t, err)
 
 	resp = <-rec.responses
-	assert.Equal(t, "Building remind101/acme-inc@master: http://conveyor/logs/01234567-89ab-cdef-0123-456789abcdef", resp.Text)
+	assert.Equal(t, "Building remind101/acme-inc:master http://conveyor/logs/01234567-89ab-cdef-0123-456789abcdef", resp.Text)
+}
+
+func TestBuildRegexp(t *testing.T) {
+	tests := []struct {
+		in  string
+		out map[string]string
+	}{
+		{`build remind101/acme-inc@topic-branch`, map[string]string{"owner": "remind101", "repo": "acme-inc", "branch": "topic-branch"}},
+		{`build remind101/acme-inc:topic-branch`, map[string]string{"owner": "remind101", "repo": "acme-inc", "branch": "topic-branch"}},
+		{`build remind101/acme-inc#topic-branch`, map[string]string{"owner": "remind101", "repo": "acme-inc", "branch": "topic-branch"}},
+	}
+
+	for _, tt := range tests {
+		m := slash.MatchTextRegexp(BuildRegexp)
+		out, ok := m.Match(slash.Command{Text: tt.in})
+		assert.True(t, ok)
+		assert.Equal(t, tt.out, out)
+	}
 }
 
 type mockBuildQueue struct {

--- a/slack/help.go
+++ b/slack/help.go
@@ -1,6 +1,6 @@
 package slack
 
 const helpText = `Enable conveyor on a repo: /conveyor enable REPO
-Build a branch on a repo: /conveyor build REPO@BRANCH`
+Build a branch on a repo: /conveyor build REPO:BRANCH`
 
 var Help = replyHandler(helpText)


### PR DESCRIPTION
`REPO@BRANCH` and `REPO#BRANCH` are both supported as well, but this changes the default to `REPO:BRANCH` which is a little more obvious when you expect a docker image to be output.
