### PR TITLE
Support empty SQS queue

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -143,10 +143,12 @@ func (q *SQSBuildQueue) receiveMessage(ch chan BuildRequest) (err error) {
 
 	var entries []*sqs.DeleteMessageBatchRequestEntry
 	defer func() {
-		_, err = q.sqs.DeleteMessageBatch(&sqs.DeleteMessageBatchInput{
-			QueueUrl: aws.String(q.QueueURL),
-			Entries:  entries,
-		})
+		if len(entries) > 0 {
+			_, err = q.sqs.DeleteMessageBatch(&sqs.DeleteMessageBatchInput{
+				QueueUrl: aws.String(q.QueueURL),
+				Entries:  entries,
+			})
+		}
 		return
 	}()
 


### PR DESCRIPTION
It blows up when the SQS queue is empty when started up. This fixes the
issue.