### PR TITLE
Make branch optional.

### DIFF
--- a/builder/docker/Makefile
+++ b/builder/docker/Makefile
@@ -8,15 +8,15 @@ test: bootstrap
 	docker run --privileged=true \
 		--volumes-from=data \
 		-e CACHE=off \
-		-e REPOSITORY=ejholmes/captain-test \
+		-e REPOSITORY=remind101/acme-inc \
 		-e BRANCH=master \
-		-e SHA=2e4edf57db00d55051c64d1568e2214858a0897d \
+		-e SHA=d4c832fcc95974bd017567b44868194a38b3b03a \
 		-e DRY=true \
 		${IMAGE}
 
 bootstrap: build data
 
-build:
+build: Dockerfile bin/*
 	docker build -t ${IMAGE} .
 
 data: data/.docker/config.json data/.ssh/id_rsa

--- a/builder/docker/bin/build
+++ b/builder/docker/bin/build
@@ -33,10 +33,6 @@ if [ -z "$REPOSITORY" ]; then
   error "REPOSITORY env var is required"
 fi
 
-if [ -z "$BRANCH" ]; then
-  error "BRANCH env var is required"
-fi
-
 if [ -z "$SHA" ]; then
   error "SHA env var is required"
 fi
@@ -74,7 +70,11 @@ setup() {
 clone() {
   status "Cloning..."
   # Clone the given branch and checkout the sha.
-  git clone --depth 50 --branch="$BRANCH" "git@github.com:${REPOSITORY}.git" "$REPOSITORY"
+  if [ -z "$BRANCH" ]; then
+    git clone --depth 50 "git@github.com:${REPOSITORY}.git" "$REPOSITORY"
+  else
+    git clone --depth 50 --branch="$BRANCH" "git@github.com:${REPOSITORY}.git" "$REPOSITORY"
+  fi
   cd "$REPOSITORY"
   git checkout -qf "$SHA"
 }
@@ -93,7 +93,9 @@ build() {
   status "Building..."
   docker build -t "$REPOSITORY" .
   docker tag "$REPOSITORY" "$REPOSITORY:$SHA"
-  docker tag -f "$REPOSITORY" "$REPOSITORY:$BRANCH" # Force tag because we pulled the last build for this branch.
+  if [ ! -z "$BRANCH" ]; then
+    docker tag -f "$REPOSITORY" "$REPOSITORY:$BRANCH" # Force tag because we pulled the last build for this branch.
+  fi
 }
 
 # Push tag pushes a tag for this repository. It will also retry up to 3 times because the docker registry sucks.
@@ -107,7 +109,9 @@ push() {
   if [ -z "$DRY" ]; then
     push_tag "latest"
     push_tag "$SHA"
-    push_tag "$BRANCH"
+    if [ ! -z "$BRANCH" ]; then
+      push_tag "$BRANCH"
+    fi
   else
     status "Dry run enabled. Not pushing."
   fi

--- a/client/conveyor/build.go
+++ b/client/conveyor/build.go
@@ -1,6 +1,7 @@
 package conveyor
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -10,7 +11,11 @@ import (
 // ArtifactInfo methods to ultimately return an Artifact and stream any
 // build logs.
 func (s *Service) Build(w io.Writer, o BuildCreateOpts) (*Artifact, error) {
-	repoSha := fmt.Sprintf("%s@%s", o.Repository, o.Sha)
+	if o.Sha == nil {
+		return nil, errors.New("cannot build without sha")
+	}
+
+	repoSha := fmt.Sprintf("%s@%s", o.Repository, *o.Sha)
 
 	a, err := s.ArtifactInfo(repoSha)
 	if err == nil {

--- a/client/conveyor/conveyor.go
+++ b/client/conveyor/conveyor.go
@@ -232,16 +232,19 @@ type Build struct {
 	State       string     `json:"state" url:"state,key"`               // the current state of the build
 }
 type BuildCreateOpts struct {
-	Branch string `json:"branch" url:"branch,key"` // the branch within the GitHub repository that the build was triggered
+	Branch *string `json:"branch,omitempty" url:"branch,omitempty,key"` // the branch within the GitHub repository that the build was triggered
 	// from
-	Repository string `json:"repository" url:"repository,key"` // the GitHub repository that this build is for
-	Sha        string `json:"sha" url:"sha,key"`               // the git commit to build
+	Repository string  `json:"repository" url:"repository,key"`       // the GitHub repository that this build is for
+	Sha        *string `json:"sha,omitempty" url:"sha,omitempty,key"` // the git commit to build
 }
 
 // Create a new build and start it. Note that you cannot start a new
 // build for a sha that is already in a "pending" or "building" state.
 // You should cancel the existing build first, or wait for it to
-// complete.
+// complete. You must specify either a `branch` OR a `sha`. If you
+// provide a `branch` but no `sha`, Conveyor will use the GitHub API to
+// resolve the HEAD commit on that branch to a sha. If you provide a
+// `sha` but no `branch`, branch caching will be disabled.
 func (s *Service) BuildCreate(o BuildCreateOpts) (*Build, error) {
 	var build Build
 	return &build, s.Post(&build, fmt.Sprintf("/builds"), o)

--- a/schema.json
+++ b/schema.json
@@ -176,7 +176,7 @@
       },
       "links": [
         {
-          "description": "Create a new build and start it. Note that you cannot start a new build for a sha that is already in a \"pending\" or \"building\" state. You should cancel the existing build first, or wait for it to complete.",
+          "description": "Create a new build and start it. Note that you cannot start a new build for a sha that is already in a \"pending\" or \"building\" state. You should cancel the existing build first, or wait for it to complete. You must specify either a `branch` OR a `sha`. If you provide a `branch` but no `sha`, Conveyor will use the GitHub API to resolve the HEAD commit on that branch to a sha. If you provide a `sha` but no `branch`, branch caching will be disabled.",
           "href": "/builds",
           "method": "POST",
           "rel": "create",
@@ -196,9 +196,7 @@
               "object"
             ],
             "required": [
-              "repository",
-              "branch",
-              "sha"
+              "repository"
             ]
           },
           "title": "Create"

--- a/schema.md
+++ b/schema.md
@@ -62,7 +62,7 @@ A build represents a request to build a git commit for a repo.
 
 ### Build Create
 
-Create a new build and start it. Note that you cannot start a new build for a sha that is already in a "pending" or "building" state. You should cancel the existing build first, or wait for it to complete.
+Create a new build and start it. Note that you cannot start a new build for a sha that is already in a "pending" or "building" state. You should cancel the existing build first, or wait for it to complete. You must specify either a `branch` OR a `sha`. If you provide a `branch` but no `sha`, Conveyor will use the GitHub API to resolve the HEAD commit on that branch to a sha. If you provide a `sha` but no `branch`, branch caching will be disabled.
 
 ```
 POST /builds
@@ -72,10 +72,15 @@ POST /builds
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **branch** | *string* | the branch within the GitHub repository that the build was triggered from | `"master"` |
 | **repository** | *string* | the GitHub repository that this build is for | `"remind101/acme-inc"` |
-| **sha** | *string* | the git commit to build | `"139759bd61e98faeec619c45b1060b4288952164"` |
 
+
+#### Optional Parameters
+
+| Name | Type | Description | Example |
+| ------- | ------- | ------- | ------- |
+| **branch** | *string* | the branch within the GitHub repository that the build was triggered from | `"master"` |
+| **sha** | *string* | the git commit to build | `"139759bd61e98faeec619c45b1060b4288952164"` |
 
 
 #### Curl Example

--- a/schemata/build.json
+++ b/schemata/build.json
@@ -102,7 +102,7 @@
   },
   "links": [
     {
-      "description": "Create a new build and start it. Note that you cannot start a new build for a sha that is already in a \"pending\" or \"building\" state. You should cancel the existing build first, or wait for it to complete.",
+      "description": "Create a new build and start it. Note that you cannot start a new build for a sha that is already in a \"pending\" or \"building\" state. You should cancel the existing build first, or wait for it to complete. You must specify either a `branch` OR a `sha`. If you provide a `branch` but no `sha`, Conveyor will use the GitHub API to resolve the HEAD commit on that branch to a sha. If you provide a `sha` but no `branch`, branch caching will be disabled.",
       "href": "/builds",
       "method": "POST",
       "rel": "create",
@@ -121,7 +121,7 @@
         "type": [
           "object"
         ],
-        "required": ["repository", "branch", "sha"]
+        "required": ["repository"]
       },
       "title": "Create"
     },

--- a/server/api/api.go
+++ b/server/api/api.go
@@ -121,8 +121,8 @@ func (s *Server) BuildCreate(w http.ResponseWriter, r *http.Request) {
 
 	b, err := s.client.Build(ctx, conveyor.BuildRequest{
 		Repository: req.Repository,
-		Branch:     req.Branch,
-		Sha:        req.Sha,
+		Branch:     emptyString(req.Branch),
+		Sha:        emptyString(req.Sha),
 	})
 	if err != nil {
 		encodeErr(w, err)
@@ -210,4 +210,13 @@ func newError(err error) *schema.Error {
 		ID:      "internal_error",
 		Message: err.Error(),
 	}
+}
+
+// returns an empty string if the pointer is nil.
+func emptyString(s *string) string {
+	if s == nil {
+		return ""
+	}
+
+	return *s
 }


### PR DESCRIPTION
This makes the git branch optional in the api and docker builder, so you can trigger a build knowing only the git sha and repo. This does mean that if you do this, caching will essentially be disabled (it'll still try to pull the master branch first, which should give a pretty good layer cache).