### PR TITLE
Botched golint Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ client/conveyor/conveyor.go: schema.json
 schema:: schema.md client/conveyor/conveyor.go
 
 lint:
-	golint $(go list ./... | grep -v /vendor/) | grep -v -E 'exported|comment'
+	golint $(shell go list ./... | grep -v /vendor/) | grep -v -E 'exported|comment'
 
 lint-all:
-	golint $(go list ./... | grep -v /vendor/)
+	golint $(shell go list ./... | grep -v /vendor/)

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -108,7 +108,7 @@ func TestWithCancel(t *testing.T) {
 				return "", nil
 			}
 
-			numCanceled += 1
+			numCanceled++
 		}
 
 		return "", nil


### PR DESCRIPTION
Accidentally used `$(go list` instead of `$(shell go list`