### PR TITLE
Switch to GitHub Apps

### DIFF
--- a/builder/github.go
+++ b/builder/github.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/google/go-github/github"
-	"golang.org/x/oauth2"
 )
 
 // GitHubClient represents a client that can create github commit statuses.
@@ -14,14 +13,8 @@ type GitHubClient interface {
 
 // NewGitHubClient returns a new GitHubClient instance. If token is an empty
 // string, then a fake client will be returned.
-func NewGitHubClient(token string) GitHubClient {
-	if token == "" {
-		return &nullGitHubClient{}
-	}
-
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	tc := oauth2.NewClient(oauth2.NoContext, ts)
-	return github.NewClient(tc).Repositories
+func NewGitHubClient(c *github.Client) GitHubClient {
+	return c.Repositories
 }
 
 // nullGitHubClient is an implementation of the GitHubClient interface that does

--- a/cmd/conveyor/worker.go
+++ b/cmd/conveyor/worker.go
@@ -14,11 +14,20 @@ import (
 
 // flags for the worker.
 var workerFlags = []cli.Flag{
+	cli.IntFlag{
+		Name:   "github.app_id",
+		Usage:  "GitHub App ID. See https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/",
+		EnvVar: "GITHUB_APP_ID",
+	},
+	cli.IntFlag{
+		Name:   "github.installation_id",
+		Usage:  "GitHub Installation ID. See https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/",
+		EnvVar: "GITHUB_INSTALLATION_ID",
+	},
 	cli.StringFlag{
-		Name:   "github.token",
-		Value:  "",
-		Usage:  "GitHub API token to use when updating commit statuses and setting up webhooks on repositories.",
-		EnvVar: "GITHUB_TOKEN",
+		Name:   "github.private_key",
+		Usage:  "Private key for the GitHub App. See https://developer.github.com/apps/building-github-apps/authentication-options-for-github-apps/",
+		EnvVar: "GITHUB_PRIVATE_KEY",
 	},
 	cli.BoolFlag{
 		Name:   "dry",


### PR DESCRIPTION
Fixes https://github.com/remind101/conveyor/issues/65

GitHub Apps has been GA for a while, so this switches Conveyor over to using a GitHub app to make authenticated requests to github (creating github commit statuses, and resolving branches to shas).

From a security perspective, this is a lot better since it provides repo level isolation, which normal access tokens do not. From a UX standpoint, it's also better because it simplifies webhook installation, and makes commit statuses come from the Conveyor app itself.

**TODO**

* [ ] Update docs on passing GitHub creds to conveyor